### PR TITLE
Fix warning for license name in gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixes
 
 * Fix csv file url in specs
+* Fix warning for license name in gemspec
 
 ### Changes
 

--- a/onlyoffice_file_helper.gemspec
+++ b/onlyoffice_file_helper.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('csv', '~> 3')
   s.add_runtime_dependency('onlyoffice_logger_helper', '~> 1')
   s.add_runtime_dependency('rubyzip', '~> 2')
-  s.license = 'AGPL-3.0'
+  s.license = 'AGPL-3.0-or-later'
 end


### PR DESCRIPTION
The warning on `gem build ...` was:

```
WARNING:  License identifier 'AGPL-3.0' is deprecated. Use an identifier from
https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
or set it to nil if you don't want to specify a license.
Did you mean 'AFL-3.0', 'APL-1.0'?

```