### PR TITLE
Fix `gem` warning about duplicate metadata source/homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * Fix csv file url in specs
 * Fix warning for license name in gemspec
+* Fix `gem` warning about duplicate metadata source/homepage
 
 ### Changes
 

--- a/onlyoffice_file_helper.gemspec
+++ b/onlyoffice_file_helper.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => "#{s.homepage}/issues",
     'changelog_uri' => "#{s.homepage}/blob/master/CHANGELOG.md",
     'documentation_uri' => "https://www.rubydoc.info/gems/#{s.name}",
-    'homepage_uri' => s.homepage,
     'source_code_uri' => s.homepage,
     'rubygems_mfa_required' => 'true'
   }


### PR DESCRIPTION
The warning is:
```
WARNING:  You have specified the uri:
  https://github.com/ONLYOFFICE-QA/onlyoffice_file_helper
for all of the following keys:
  homepage_uri
  source_code_uri
Only the first one will be shown on rubygems.org
WARNING:  See https://guides.rubygems.org/specification-reference/ for help

```