### PR TITLE
Cleanup `require` statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changes
 
 * Remove `csv` dependency, since it's not used
+* Remove `open-uri` code requirement, since it's not used
+* Move `require 'find'` to correct source file
 
 ## 2.0.0 (2024-01-25)
 

--- a/lib/onlyoffice_file_helper.rb
+++ b/lib/onlyoffice_file_helper.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 require 'zip'
-require 'open-uri'
 require 'onlyoffice_logger_helper'
-require 'find'
 require 'onlyoffice_file_helper/create_methods'
 require 'onlyoffice_file_helper/directory_methods'
 require 'onlyoffice_file_helper/file_methods'

--- a/lib/onlyoffice_file_helper/directory_methods.rb
+++ b/lib/onlyoffice_file_helper/directory_methods.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'find'
+
 module OnlyofficeFileHelper
   # Methods used to work with directories
   module DirectoryMethods


### PR DESCRIPTION
* Remove `open-uri` code requirement, since it's not used
* Move `require 'find'` to correct source file