### PR TITLE
Actualize list of rubies in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,7 +6,7 @@ jobs:
     continue-on-error: ${{ matrix.allow-failures }}
     strategy:
       matrix:
-        ruby: ['3.0', '3.1', '3.2', '3.3']
+        ruby: ['3.1', '3.2', '3.3', '3.4']
         allow-failures: [false]
         include:
           - ruby: head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## master (unreleased)
 
+### New Features
+
+* Add `ruby-3.4` to CI
+
 ### Changes
 
 * Fix `rubocop-rspec-2.27.0` cop `RSpec/DescribedClass` warnings.
 * Fix `rubocop-1.65.0` cop `Gemspec/AddRuntimeDependency`
+* Remove `ruby-3.0` from CI, since it's EOLed
 
 ## 2.1.0 (2024-01-26)
 


### PR DESCRIPTION
Implement #543

* Add `ruby-3.4` to CI
* Remove `ruby-3.0` from CI, since it's EOLed
